### PR TITLE
Return the AST

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -51,6 +51,8 @@ const addIterations = (astRoot) => {
   addDeclaration(astRoot);
   removeDeclaration(astRoot);
   getParam(astRoot);
+	
+	return astRoot;
 
 };
 


### PR DESCRIPTION
This basically returns the AST so you can do this instead:
```javascript
const ast = addIterations(css.parse(".foo{bar:20px;}"));
```
This allows Typescript definitions and such to be created for this package.